### PR TITLE
feat: 카테고리별, 신간, 도서 목록 조회 및 도서 목록 조회 페이징

### DIFF
--- a/controller/BookController.js
+++ b/controller/BookController.js
@@ -2,43 +2,47 @@ const conn = require('../mariadb');
 const {StatusCodes} = require('http-status-codes');
 
 const allBooks = (req, res) => {
-    let {category_id} = req.query;
+    let {category_id, news, limit, currentPage} = req.query;
+    let offset = limit * (currentPage-1);
 
-    if(category_id) {
-        let sql = `SELECT * FROM books WHERE category_id=?`;
-        conn.query(sql, category_id,
-            (err, results) => {
-                if(err) {
-                    console.log(err)
-                    return res.status(StatusCodes.BAD_REQUEST).end();
-                }
-            
-                if(results.length) {
-                    return res.status(StatusCodes.OK).json(results);
-                }else {
-                    return res.status(StatusCodes.NOT_FOUND).end();
-                }
-            }
-        )
+    let sql = `SELECT * FROM books`;
+    let values = [];
+    
+    if (category_id && news) {
+        sql += ` WHERE category_id=? AND pub_date BETWEEN DATE_SUB(NOW(), INTERVAL 1 MONTH) AND NOW()`;
+        values.push(category_id);
+    } 
+    else if(category_id) {
+        sql += ` WHERE category_id=?`;
+        values.push(category_id);
+    } 
+    else if (news) {
+        sql += ` WHERE pub_date BETWEEN DATE_SUB(NOW(), INTERVAL 1 MONTH) AND NOW()`;
     }
-    else {
-        let sql = `SELECT * FROM books`;
-        conn.query(sql, 
-            (err, results) => {
-                if(err) {
-                    console.log(err)
-                    return res.status(StatusCodes.BAD_REQUEST).end();
-                }
+    sql += ` LIMIT ? OFFSET ?`;
+    values.push(parseInt(limit), offset);
+
+    conn.query(sql, values,
+        (err, results) => {
+            if(err) {
+                console.log(err)
+                return res.status(StatusCodes.BAD_REQUEST).end();
+            }
+        
+            if(results.length) {
                 return res.status(StatusCodes.OK).json(results);
+            }else {
+                return res.status(StatusCodes.NOT_FOUND).end();
             }
-        )
-    }
+        }
+    )
 };
 
 const bookDetail = (req, res) => {
     let {id} = req.params;
   
-    let sql = `SELECT * FROM books WHERE id=?`;
+    let sql = `SELECT * FROM books LEFT JOIN category 
+               ON books.category_id = category.id WHERE books.id=?`;
     conn.query(sql, id,
         (err, results) => {
             if(err) {

--- a/data.sql
+++ b/data.sql
@@ -1,16 +1,69 @@
-INSERT INTO books (title, form, isbn, summary, detail, author, pages, contents, price, pub_date)
-VALUES ('어린왕자', '종이책', '0', '어린 왕자는 작은 왕국에서 왔다.', '어린 왕자는 작은 왕국에서 왔다. 그는 여행 중 다양한 이야기를 만나면서 성장한다.',
+//동화
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('어린왕자', 12, 0,'종이책', 0, '어린 왕자는 작은 왕국에서 왔다.', '어린 왕자는 작은 왕국에서 왔다. 그는 여행 중 다양한 이야기를 만나면서 성장한다.',
 '김왕자', 100, '목차', 20000, '2019-01-01');
 
-INSERT INTO books (title, form, isbn, summary, detail, author, pages, contents, price, pub_date)
-VALUES ('신데렐라', '종이책', '1','신데렐라는 부모님이 죽은 뒤 어려운 삶을 살지만 마법을 통해 공주로 변하게 된다.', '신데렐라는 부모님이 죽은 뒤 어려운 삶을 살지만 마법을 통해 공주로 변하게 된다. 전통적인 동화의 대표적인 이야기 중 하나이다.',
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('신데렐라', 13, 0, '종이책', 1,'신데렐라는 부모님이 죽은 뒤 어려운 삶을 살지만 마법을 통해 공주로 변하게 된다.', '신데렐라는 부모님이 죽은 뒤 어려운 삶을 살지만 마법을 통해 공주로 변하게 된다. 전통적인 동화의 대표적인 이야기 중 하나이다.',
 '김델라', 150, '목차', 19000, '2023-12-01');
 
-INSERT INTO books (title, form, isbn, summary, detail, author, pages, contents, price, pub_date)
-VALUES ('백설공주', '종이책', '2', '매서운 악행에 시달리던 백설공주는 세 난쟁이와 함께 평화로운 삶을 찾아가는 이야기.', '매서운 악행에 시달리던 백설공주는 세 난쟁이와 함께 평화로운 삶을 찾아가는 이야기. 그녀의 아름다움이 동화의 주요 테마 중 하나이다.',
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('백설공주', 14, 0, '종이책', 2, '매서운 악행에 시달리던 백설공주는 세 난쟁이와 함께 평화로운 삶을 찾아가는 이야기.', '매서운 악행에 시달리던 백설공주는 세 난쟁이와 함께 평화로운 삶을 찾아가는 이야기. 그녀의 아름다움이 동화의 주요 테마 중 하나이다.',
 '김백설', 120, '목차', 22000, '2023-11-01');
 
-INSERT INTO books (title, form, isbn, summary, detail, author, pages, contents, price, pub_date)
-VALUES ('흥부와 놀부', '종이책', '3', '흥부와 놀부는 형제지만 운명은 매우 다르게 펼쳐진다. 성실함과 게으름의 결말을 다룬 전래동화.',
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('흥부와 놀부', 15, 0, '종이책', 3, '흥부와 놀부는 형제지만 운명은 매우 다르게 펼쳐진다. 성실함과 게으름의 결말을 다룬 전래동화.',
 '흥부와 놀부는 형제지만 운명은 매우 다르게 펼쳐진다. 성실함과 게으름의 결말을 다룬 전래동화.',
 '김덕수', 205, '목차', 20000, '2023-12-08');
+
+
+//소설
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('단 한 사람', 12, 1, '종이책', 4, ' 위태로운 마음과 허영심으로 가득 찬 그녀와 함께 다시는 돌이킬 수 없는 로마에서의 여름을 맞이하는데…', '달콤한 사랑에 중독된 도시 로마에서 두 사람은 밤새도록 도시 이곳저곳을 돌아다니며 늦은 봄 새벽 바다의 차가운 바람 속에서 서로에 대해 묘한 감정을 느끼게 된다. ',
+'최진영', 405, '목차', 26000, '2023-11-05');
+
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('사자 츠나구', 13, 1,'ebook', 5, '이젠 세상엔 없는 그 사람과 다시 한번 만날 수 있다면!', '츠나구는 죽은 자와 산 자를 만나게 해줄 수 있는 창구이다. 산 자의 의뢰를 받아 죽은 자와 교섭하고 면회의 장을 만들어주는 츠나구의 이야기',
+'츠지무라 미즈키', 405, '목차', 32000, '2024-01-02');
+
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('11문자 살인사건', 14, 1,'ebook', 6, '애인의 살인범을 쫓는 여성 추리소설 작가가 진실에 다가갈수록 그녀가 만나는 사람도 하나둘씩 살해당한다. ', '누가 편지를 보냈는지에서부터 범인이 누구이고, 어떤 트릭이 사용되었는지 주인공과 함께 추리 대결을 펼치게 된다. ',
+'히가시노 게이고', 405, '목차', 23000, '2024-01-05');
+
+
+
+//인문
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('우리 인생에 바람을 초대하려면', 32, 2,'종이책', 7, '우리의 식생활과 베이커리 시장의 판도에 큰 변화가 발생한 이야기', '유럽 빵 문화의 대표 격이라 할 프랑스와 우리나라의 베이커리 시장의 트랜드 변화를 간단히 비교해보자',
+'파스칼 브뤼크네르', 265, '목차', 12000, '2023-12-12');
+
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('꽃말의 탄생', 33, 2,'ebook', 8, '많은 이들에게 사랑받는 꽃 이야기.', '우리에게 익숙한 꽃들이 오랜 세월 동안 어떻게 그런 그런 꽃말을 지니게 되었는지 그 유래를 찾아서 신화, 문학, 역사, 미신등 서양 문화를 소개한 책이다.',
+'샐리 쿨타드', 320, '목차', 29000, '2023-12-27');
+
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('서사의 위기', 34, 2,'종이책', 9, '피로사회 이후 10여 년 만에 새로운 화두를 던지는 이 책의 핵심 키워드는 서사와 스토리다', '한국 사회를 뜨겁게 달궜던 재독 철학자 한병철이, 이번에는 빠르게 나타났다 사라지는 이슈만 좇느라 정작 자기의 생각으로부터 멀어져 버린 스토리 중독 사회를 고발한다.',
+'한병철', 182, '목차', 12000, '2024-01-12');
+
+
+//건강
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('코어 마인드', 45, 3,'종이책', 10, '세상이 내 마음 같지 않을 때도 유일하게 가능한 것은 내 마음을 돌보는 일', '늘 예상치 못한 고난과 어려움에 부딪히며 부정적 감정에 휘둘릴 수밖에 없는 우리 인생 전반에 변화를 가져다줄 수 있는 책이다."',
+'지나영', 182, '목차', 12000, '2024-01-12');
+
+//컴퓨터
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('개발자로 살아남기', 67 , 4,'종이책', 11, '평생 개발자를 꿈꾼다면 30년 커리어패스를 설계하자', '이 책은 주니어/시니어 개발자, 팀장, 리드에 이르기까지 다양한 역할에 필요한 역량을 9가지 기술 중심으로 소개한다.',
+'박종철', 182, '목차', 12000, '2024-01-12');
+
+//자기개발
+INSERT INTO books (title, img, category_id, form, isbn, summary, detail, author, pages, contents, price, pub_date)
+VALUES ('대화력의 비밀', 49, 5,'ebook', 12, '말 잘하는 사람은 무엇이 다를까? 당신의 말버릇을 점검해 보라!', '관점이 다른 사람을 내 편으로 만들고, 문제를 해결하는 방법을 찾고, 내면의 잠재력을 끌어내는 언어의 기술을 ‘대화’에 적용할 수 있도록 예를 들어가며 설명한다. ',
+'김지영', 182, '목차', 12000, '2024-01-12');
+
+SELECT * FROM books left 
+join category on books.category_id = category.id
+
+
+SELECT * FROM books left 
+join category on books.category_id = category.id where books.id=1


### PR DESCRIPTION
## 개요
카테고리별 도서 신간 조회, 전체 도서 신간 조회, 도서 목록 조회 페이징 기능을 추가했습니다.

## 주요 구현 내용
- allBooks 함수에 페이징을 위한 쿼리 파라미터 `limit` 및 `currentPage`를 추가하였습니다.
- `limit`과 `offset` 을 계산하여 데이터베이스 쿼리에 적용하도록 수정하였습니다.
- 기존의 검색 조건에 페이징 조건을 추가하였습니다.
- 파리미터 `news`를 받아 신간을 조회할 수 있습니다. 

## sql 작성시 주의할 점
- `limit`과 `offset` 은 쿼리의 맨 마지막에 위치해야 함으로 이 부분을 고려해야 함
```
let {category_id, news, limit, currentPage} = req.query;
let offset = limit * (currentPage-1);

let sql = `SELECT * FROM books`;
let values = [];

if (category_id && news) {
} 
else if(category_id) {
}

sql += ` LIMIT ? OFFSET ?`;
values.push(parseInt(limit), offset);
```