### PR TITLE
feat: 장바구니 담기

### DIFF
--- a/controller/CartController.js
+++ b/controller/CartController.js
@@ -1,0 +1,32 @@
+const conn = require('../mariadb');
+const {StatusCodes} = require('http-status-codes');
+
+
+const addToCart = (req, res) => {
+    const {book_id, quantity, user_id} = req.body;
+    
+    let sql = `INSERT INTO cartItems (book_id, quantity, user_id) VALUES(?, ?, ?);`;
+    let values = [book_id, quantity, user_id];
+    conn.query(sql, values,
+        (err, results) => {
+            if(err) {
+                console.log(err)
+                return res.status(StatusCodes.BAD_REQUEST).end();
+            }
+        
+            return res.status(StatusCodes.CREATED).json(results);
+        }
+    )
+}
+
+const getCartItems = (req, res) => {
+    res.json('전체 장바구니 조회');
+}
+
+const removeCartItem= (req, res) => {
+    res.json('장바구니 개별 삭제');
+}
+
+
+
+module.exports = {addToCart, getCartItems, removeCartItem};

--- a/data.sql
+++ b/data.sql
@@ -98,3 +98,6 @@ SELECT *,
     LEFT JOIN category 
     ON books.category_id = category.id 
     WHERE books.id=1
+
+//장바구니 담기
+INSERT INTO cartItems (book_id, quantity, user_id) VALUES(1, 1, 1);

--- a/routes/carts.js
+++ b/routes/carts.js
@@ -1,23 +1,11 @@
 const express = require('express');
 const router = express.Router();
+const {addToCart, getCartItems, removeCartItem} = require('../controller/CartController')
 
 router.use(express.json())
 
-router.get('/', (req, res) => {
-    res.json('전체 장바구니 조회');
-});
-
-
-router.post('/', (req, res) => {
-    res.json('장바구니 담기');
-});
-
-router.delete('/:id', (req, res) => {
-    res.json('장바구니 개별 삭제');
-});
-
-// router.get('/', (req, res) => {
-//     res.json('주문 예상 상품 목록 조회');
-// });
+router.post('/', addToCart);
+router.get('/', getCartItems);
+router.delete('/:id', removeCartItem);
 
 module.exports = router;


### PR DESCRIPTION
## 개요
장바구니 담기(추가) 기능을 추가했습니다.

## 주요 구현 내용
- book_id, quantity, user_id를 통해 장바구니에 담을 수 있습니다.
- 관련 API 명세서 및 데이터베이스를 수정했습니다.

## 이슈
1. mysql - `errno: 121 "Duplicate key on write or update`
2. mysql = `error: 1061 duplicate key name`

## 해결방안
1. 고유 제약 조건을 가진 컬럼에 중복된 값을 삽입하려고 할 때 발생하는 문제이다. 따라서 중복된 키가 발생하는 컬럼에 대해 고유(unique) 제약 조건이 제대로 설정되어 있는지 확인하고 제약 조건 이름을 변경해준다.

2. 외래 키를 참조하는 컬럼에는 인덱스가 설정된다. 이미 다른 테이블에서 외래키를 설정했기 때문에 index 이름이 같기 때문에 index 명을 변경해줘서 해결해줬다.

> 참고 ) FK 제약조건 이름 짓기
>  &emsp; &emsp; fk_기준 테이블명_참조테이블명_참조키
>  &emsp; &emsp; 예) fk_cartItems_users_id



## 계획
- user_id 대신 jwt 를 사용할 계획입니다.